### PR TITLE
docs(roles): add separation of duties rule for pr authorship (#33)

### DIFF
--- a/docs/adr/0004-contribution-workflow.md
+++ b/docs/adr/0004-contribution-workflow.md
@@ -219,11 +219,14 @@ N/A
 Tasks and reviews are assigned based on InnerSource roles. See `docs/standards/roles.md`
 for full role definitions.
 
-| InnerSource Role | Task Types                       | PR Actions                      |
-| ---------------- | -------------------------------- | ------------------------------- |
-| **Owner**        | Repo config, process, direction  | Final approval, merge authority |
-| **Maintainer**   | Code review, architecture review | Approve, request changes        |
-| **Contributor**  | Implementation, bug fixes, tests | Submit PRs, address feedback    |
+| InnerSource Role | Task Types                       | PR Actions                       |
+| ---------------- | -------------------------------- | -------------------------------- |
+| **Owner**        | Repo config, process, direction  | Final approval, merge authority  |
+| **Maintainer**   | Code review, architecture review | Approve, request changes         |
+| **Contributor**  | Implementation, bug fixes, tests | **Submit PRs**, address feedback |
+
+**Separation of Duties:** Only Contributor roles may open PRs. Owner and Maintainer roles review
+and approve but do not author PRs. See `docs/standards/roles.md` for full policy.
 
 **Reviewer Assignment by Change Type:**
 

--- a/docs/standards/roles.md
+++ b/docs/standards/roles.md
@@ -15,11 +15,32 @@ planning, and validation. Roles map to InnerSource responsibilities for task ass
 
 Roles map to standard InnerSource roles to guide task assignment:
 
-| InnerSource Role | Responsibilities                                | Task Types                                             | PR Actions                      |
-| ---------------- | ----------------------------------------------- | ------------------------------------------------------ | ------------------------------- |
-| **Owner**        | Process, admin, repo config, direction          | Repo settings, branch protection, process docs         | Final approval, merge authority |
-| **Maintainer**   | Review, approve, request changes, quality gates | Code review, architecture review, documentation review | Approve, request changes, block |
-| **Contributor**  | Implement change, write code/tests/docs         | Feature implementation, bug fixes, test creation       | Submit PRs, address feedback    |
+| InnerSource Role | Responsibilities                                | Task Types                                             | PR Actions                       |
+| ---------------- | ----------------------------------------------- | ------------------------------------------------------ | -------------------------------- |
+| **Owner**        | Process, admin, repo config, direction          | Repo settings, branch protection, process docs         | Final approval, merge authority  |
+| **Maintainer**   | Review, approve, request changes, quality gates | Code review, architecture review, documentation review | Approve, request changes, block  |
+| **Contributor**  | Implement change, write code/tests/docs         | Feature implementation, bug fixes, test creation       | **Submit PRs**, address feedback |
+
+### Separation of Duties
+
+**Rule:** Only Contributor roles may open pull requests. Owner and Maintainer roles review and
+approve but do not author PRs.
+
+| Role            | Can Open PR | Can Review PR | Can Merge PR |
+| --------------- | ----------- | ------------- | ------------ |
+| **Owner**       | No          | Yes           | Yes          |
+| **Maintainer**  | No          | Yes           | No           |
+| **Contributor** | Yes         | No            | No           |
+
+**Rationale:**
+
+- Prevents self-approval of changes
+- Ensures independent review of all code
+- Maintains audit trail integrity
+- Aligns with compliance requirements (SOC 2, ISO 27001)
+
+**Exception:** Repository bootstrap or emergency fixes may require Owner to submit PRs, but these
+must be reviewed by another Owner or external reviewer before merge.
 
 ### Task Assignment by InnerSource Role
 


### PR DESCRIPTION
## Summary

- Add process rule that Owner and Maintainer InnerSource roles cannot open pull requests
- Only Contributor roles may submit PRs; Owner/Maintainer roles review and approve

## Changes

- Update `docs/standards/roles.md` with full separation of duties policy including rationale and exceptions
- Update `docs/adr/0004-contribution-workflow.md` with summary and reference to policy

## Rationale

- Prevents self-approval of changes
- Ensures independent review of all code
- Maintains audit trail integrity
- Aligns with compliance requirements (SOC 2, ISO 27001)

## Checklist

- [x] PR title follows `type(scope): description` format
- [x] Linked to issue with `Closes #33`
- [x] Documentation updated
- [x] Self-review completed

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)