### PR TITLE
feat: add developer environment and documentation infrastructure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "McjCoderOrg.ClaudeAutoResume",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "esbenp.prettier-vscode",
+        "streetsidesoftware.code-spell-checker",
+        "eamodio.gitlens",
+        "davidanson.vscode-markdownlint"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "[csharp]": {
+          "editor.defaultFormatter": "ms-dotnettools.csharp"
+        },
+        "cSpell.language": "en-GB"
+      }
+    }
+  },
+  "postCreateCommand": "npm install && dotnet restore && dotnet tool restore",
+  "remoteUser": "vscode"
+}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/docusaurus/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs/docusaurus/package-lock.json
+
+      - name: Install dependencies
+        working-directory: docs/docusaurus
+        run: npm ci
+
+      - name: Build documentation
+        working-directory: docs/docusaurus
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/docusaurus/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/docusaurus/.gitignore
+++ b/docs/docusaurus/.gitignore
@@ -1,0 +1,24 @@
+# Dependencies
+node_modules/
+
+# Production build
+build/
+
+# Generated files
+.docusaurus/
+.cache-loader/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Misc
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/docs/docusaurus/docs/architecture/decisions.md
+++ b/docs/docusaurus/docs/architecture/decisions.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 2
+---
+
+# Architecture Decisions
+
+We document significant architectural decisions using Architecture Decision Records (ADRs).
+
+## What is an ADR?
+
+An Architecture Decision Record captures an important architectural decision along with
+its context and consequences.
+
+## ADR List
+
+Our ADRs are maintained in the repository at `docs/adr/`. Key decisions include:
+
+| ADR  | Title                    |
+| ---- | ------------------------ |
+| 0001 | License Selection        |
+| 0010 | Code Formatting          |
+| 0013 | Testing Framework        |
+| 0018 | CLI Design               |
+| 0021 | CI/CD Pipeline           |
+| 0022 | Versioning and Changelog |
+| 0029 | Developer Environment    |
+
+## Reading ADRs
+
+Each ADR follows this structure:
+
+1. **Status**: Proposed, Accepted, Deprecated, or Superseded
+2. **Context**: Why was this decision needed?
+3. **Decision**: What was decided?
+4. **Consequences**: What are the positive and negative outcomes?
+
+See the full list at
+[docs/adr/](https://github.com/mcj-coder-org/claude-auto-resume/tree/main/docs/adr).

--- a/docs/docusaurus/docs/architecture/overview.md
+++ b/docs/docusaurus/docs/architecture/overview.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+---
+
+# Architecture Overview
+
+High-level architecture of Claude Auto Resume.
+
+## System Components
+
+```text
+┌─────────────────┐     ┌─────────────────┐
+│   Claude CLI    │────▶│ Claude Auto     │
+│                 │     │ Resume          │
+└─────────────────┘     └────────┬────────┘
+                                 │
+                    ┌────────────┼────────────┐
+                    ▼            ▼            ▼
+              ┌──────────┐ ┌──────────┐ ┌──────────┐
+              │ Session  │ │ Config   │ │ Storage  │
+              │ Manager  │ │ Manager  │ │ Provider │
+              └──────────┘ └──────────┘ └──────────┘
+```
+
+## Design Principles
+
+- **Single Responsibility**: Each component has one clear purpose
+- **Dependency Injection**: Loose coupling through interfaces
+- **Testability**: All components are unit testable
+- **Cross-Platform**: Works on Windows, macOS, and Linux
+
+## Key Interfaces
+
+- `ISessionManager`: Manages conversation sessions
+- `IConfigurationProvider`: Handles configuration
+- `IStorageProvider`: Abstracts file storage

--- a/docs/docusaurus/docs/contributing/coding-standards.md
+++ b/docs/docusaurus/docs/contributing/coding-standards.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 2
+---
+
+# Coding Standards
+
+Code style and quality guidelines for contributors.
+
+## Code Formatting
+
+We use automated formatting tools:
+
+- **C#**: `dotnet format` with `.editorconfig` rules
+- **Markdown/JSON/YAML**: Prettier
+
+Run formatting check:
+
+```bash
+dotnet format --verify-no-changes
+npm run lint:format
+```
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+### Types
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting)
+- `refactor`: Code refactoring
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `build`: Build system changes
+- `ci`: CI/CD changes
+- `chore`: Maintenance tasks
+
+## Pre-commit Hooks
+
+Git hooks automatically run on commit:
+
+- **commitlint**: Validates commit message format
+- **prettier**: Formats staged files
+- **cspell**: Checks spelling
+- **secretlint**: Detects secrets

--- a/docs/docusaurus/docs/contributing/development-setup.md
+++ b/docs/docusaurus/docs/contributing/development-setup.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 1
+---
+
+# Development Setup
+
+Set up your development environment for contributing to Claude Auto Resume.
+
+## Prerequisites
+
+- .NET 10.0 SDK
+- Node.js 22+
+- Git
+
+## Quick Setup
+
+### Using Dev Container (Recommended)
+
+1. Install [Docker](https://www.docker.com/) and [VS Code](https://code.visualstudio.com/)
+2. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+3. Open the repository in VS Code
+4. Click "Reopen in Container" when prompted
+
+### Local Setup
+
+Run the setup script for your platform:
+
+**Windows (PowerShell):**
+
+```powershell
+./scripts/setup.ps1
+```
+
+**macOS/Linux:**
+
+```bash
+./scripts/setup.sh
+```
+
+## Verify Setup
+
+Build the project:
+
+```bash
+dotnet build
+```
+
+Run tests:
+
+```bash
+dotnet test
+```

--- a/docs/docusaurus/docs/contributing/testing.md
+++ b/docs/docusaurus/docs/contributing/testing.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 3
+---
+
+# Testing
+
+Guidelines for writing and running tests.
+
+## Test Projects
+
+| Project                                    | Description        |
+| ------------------------------------------ | ------------------ |
+| `McjCoderOrg.ClaudeAutoResume.Tests`       | Unit tests         |
+| `McjCoderOrg.ClaudeAutoResume.ArchTests`   | Architecture tests |
+| `McjCoderOrg.ClaudeAutoResume.E2ETests`    | End-to-end tests   |
+| `McjCoderOrg.ClaudeAutoResume.SystemTests` | System tests       |
+
+## Running Tests
+
+Run all tests:
+
+```bash
+dotnet test
+```
+
+Run specific test project:
+
+```bash
+dotnet test tests/McjCoderOrg.ClaudeAutoResume.Tests
+```
+
+Run with coverage:
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+## Writing Tests
+
+We use xUnit as the testing framework:
+
+```csharp
+public class CalculatorTests
+{
+    [Fact]
+    public void Add_TwoNumbers_ReturnsSum()
+    {
+        // Arrange
+        var calculator = new Calculator();
+
+        // Act
+        var result = calculator.Add(2, 3);
+
+        // Assert
+        Assert.Equal(5, result);
+    }
+}
+```
+
+## Test-Driven Development
+
+Follow the TDD cycle:
+
+1. **Red**: Write a failing test
+2. **Green**: Write minimal code to pass
+3. **Refactor**: Improve code quality

--- a/docs/docusaurus/docs/getting-started/installation.md
+++ b/docs/docusaurus/docs/getting-started/installation.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 1
+---
+
+# Installation
+
+This guide covers how to install Claude Auto Resume.
+
+## Prerequisites
+
+- .NET 10.0 Runtime or later
+- Claude CLI installed and configured
+
+## Installation Methods
+
+### Via dotnet tool (Recommended)
+
+```bash
+dotnet tool install --global McjCoderOrg.ClaudeAutoResume
+```
+
+### Via standalone executable
+
+Download the appropriate binary for your platform from the
+[GitHub Releases](https://github.com/mcj-coder-org/claude-auto-resume/releases) page:
+
+- `claude-auto-resume-win-x64.exe` - Windows x64
+- `claude-auto-resume-linux-x64` - Linux x64
+- `claude-auto-resume-osx-x64` - macOS Intel
+- `claude-auto-resume-osx-arm64` - macOS Apple Silicon
+
+## Verification
+
+After installation, verify it's working:
+
+```bash
+claude-auto-resume --version
+```

--- a/docs/docusaurus/docs/getting-started/quick-start.md
+++ b/docs/docusaurus/docs/getting-started/quick-start.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 2
+---
+
+# Quick Start
+
+Get up and running with Claude Auto Resume in minutes.
+
+## Basic Usage
+
+Start a new session:
+
+```bash
+claude-auto-resume
+```
+
+Resume an existing session:
+
+```bash
+claude-auto-resume --resume
+```
+
+## Next Steps
+
+- [Configure your preferences](../guides/configuration)
+- [Learn about advanced usage](../guides/usage)

--- a/docs/docusaurus/docs/guides/configuration.md
+++ b/docs/docusaurus/docs/guides/configuration.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 1
+---
+
+# Configuration
+
+Claude Auto Resume can be configured through environment variables and configuration files.
+
+## Configuration File
+
+Create a configuration file at `~/.config/claude-auto-resume/config.json`:
+
+```json
+{
+  "autoSave": true,
+  "saveInterval": 60,
+  "maxSessions": 10
+}
+```
+
+## Environment Variables
+
+| Variable               | Description              | Default |
+| ---------------------- | ------------------------ | ------- |
+| `CLAUDE_AUTO_SAVE`     | Enable auto-save         | `true`  |
+| `CLAUDE_SAVE_INTERVAL` | Save interval in seconds | `60`    |
+| `CLAUDE_MAX_SESSIONS`  | Maximum saved sessions   | `10`    |

--- a/docs/docusaurus/docs/guides/usage.md
+++ b/docs/docusaurus/docs/guides/usage.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 2
+---
+
+# Usage Guide
+
+Detailed guide on using Claude Auto Resume effectively.
+
+## Session Management
+
+### Listing Sessions
+
+```bash
+claude-auto-resume list
+```
+
+### Resuming a Specific Session
+
+```bash
+claude-auto-resume resume --session <session-id>
+```
+
+### Deleting a Session
+
+```bash
+claude-auto-resume delete --session <session-id>
+```
+
+## Command-Line Options
+
+| Option      | Description                    |
+| ----------- | ------------------------------ |
+| `--resume`  | Resume the most recent session |
+| `--session` | Specify a session ID           |
+| `--list`    | List all saved sessions        |
+| `--version` | Display version information    |
+| `--help`    | Display help information       |

--- a/docs/docusaurus/docs/intro.md
+++ b/docs/docusaurus/docs/intro.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 1
+---
+
+# Introduction
+
+Welcome to Claude Auto Resume documentation.
+
+Claude Auto Resume provides automatic resume functionality for the Claude CLI, enabling
+persistent conversation sessions that can be resumed after interruptions.
+
+## Features
+
+- **Automatic Session Persistence**: Conversations are automatically saved and can be resumed
+- **Cross-Platform Support**: Works on Windows, macOS, and Linux
+- **Integration with Claude CLI**: Seamless integration with the official Claude CLI
+
+## Quick Links
+
+- [Installation Guide](./getting-started/installation)
+- [Quick Start](./getting-started/quick-start)
+- [Configuration](./guides/configuration)
+- [Contributing](./contributing/development-setup)

--- a/docs/docusaurus/docusaurus.config.ts
+++ b/docs/docusaurus/docusaurus.config.ts
@@ -1,0 +1,90 @@
+import { themes as prismThemes } from "prism-react-renderer";
+import type { Config } from "@docusaurus/types";
+import type * as Preset from "@docusaurus/preset-classic";
+
+const config: Config = {
+  title: "Claude Auto Resume",
+  tagline: "Automatic resume functionality for Claude CLI",
+  favicon: "img/favicon.ico",
+
+  url: "https://mcj-coder-org.github.io",
+  baseUrl: "/claude-auto-resume/",
+
+  organizationName: "mcj-coder-org",
+  projectName: "claude-auto-resume",
+
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "warn",
+
+  i18n: {
+    defaultLocale: "en-GB",
+    locales: ["en-GB"],
+  },
+
+  presets: [
+    [
+      "classic",
+      {
+        docs: {
+          sidebarPath: "./sidebars.ts",
+          editUrl:
+            "https://github.com/mcj-coder-org/claude-auto-resume/tree/main/docs/docusaurus/",
+        },
+        blog: false,
+        theme: {
+          customCss: "./src/css/custom.css",
+        },
+      } satisfies Preset.Options,
+    ],
+  ],
+
+  themeConfig: {
+    navbar: {
+      title: "Claude Auto Resume",
+      items: [
+        {
+          type: "docSidebar",
+          sidebarId: "docsSidebar",
+          position: "left",
+          label: "Documentation",
+        },
+        {
+          href: "https://github.com/mcj-coder-org/claude-auto-resume",
+          label: "GitHub",
+          position: "right",
+        },
+      ],
+    },
+    footer: {
+      style: "dark",
+      links: [
+        {
+          title: "Docs",
+          items: [
+            {
+              label: "Getting Started",
+              to: "/docs/intro",
+            },
+          ],
+        },
+        {
+          title: "More",
+          items: [
+            {
+              label: "GitHub",
+              href: "https://github.com/mcj-coder-org/claude-auto-resume",
+            },
+          ],
+        },
+      ],
+      copyright: `Copyright © ${new Date().getFullYear()} McjCoderOrg. Built with Docusaurus.`,
+    },
+    prism: {
+      theme: prismThemes.github,
+      darkTheme: prismThemes.dracula,
+      additionalLanguages: ["csharp", "powershell", "bash", "json", "yaml"],
+    },
+  } satisfies Preset.ThemeConfig,
+};
+
+export default config;

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "claude-auto-resume-docs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "docusaurus": "docusaurus",
+    "start": "docusaurus start",
+    "build": "docusaurus build",
+    "swizzle": "docusaurus swizzle",
+    "deploy": "docusaurus deploy",
+    "clear": "docusaurus clear",
+    "serve": "docusaurus serve",
+    "write-translations": "docusaurus write-translations",
+    "write-heading-ids": "docusaurus write-heading-ids"
+  },
+  "dependencies": {
+    "@docusaurus/core": "^3.7.0",
+    "@docusaurus/preset-classic": "^3.7.0",
+    "@mdx-js/react": "^3.0.0",
+    "clsx": "^2.0.0",
+    "prism-react-renderer": "^2.3.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@docusaurus/module-type-aliases": "^3.7.0",
+    "@docusaurus/types": "^3.7.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
+    ]
+  },
+  "engines": {
+    "node": ">=18.0"
+  }
+}

--- a/docs/docusaurus/sidebars.ts
+++ b/docs/docusaurus/sidebars.ts
@@ -1,0 +1,33 @@
+import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
+
+const sidebars: SidebarsConfig = {
+  docsSidebar: [
+    "intro",
+    {
+      type: "category",
+      label: "Getting Started",
+      items: ["getting-started/installation", "getting-started/quick-start"],
+    },
+    {
+      type: "category",
+      label: "Guides",
+      items: ["guides/configuration", "guides/usage"],
+    },
+    {
+      type: "category",
+      label: "Contributing",
+      items: [
+        "contributing/development-setup",
+        "contributing/coding-standards",
+        "contributing/testing",
+      ],
+    },
+    {
+      type: "category",
+      label: "Architecture",
+      items: ["architecture/overview", "architecture/decisions"],
+    },
+  ],
+};
+
+export default sidebars;

--- a/docs/docusaurus/src/css/custom.css
+++ b/docs/docusaurus/src/css/custom.css
@@ -1,0 +1,27 @@
+/**
+ * Custom CSS for Claude Auto Resume documentation.
+ * See https://docusaurus.io/docs/styling-layout
+ */
+
+:root {
+  --ifm-color-primary: #2e8555;
+  --ifm-color-primary-dark: #29784c;
+  --ifm-color-primary-darker: #277148;
+  --ifm-color-primary-darkest: #205d3b;
+  --ifm-color-primary-light: #33925d;
+  --ifm-color-primary-lighter: #359962;
+  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-code-font-size: 95%;
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] {
+  --ifm-color-primary: #25c2a0;
+  --ifm-color-primary-dark: #21af90;
+  --ifm-color-primary-darker: #1fa588;
+  --ifm-color-primary-darkest: #1a8870;
+  --ifm-color-primary-light: #29d5b0;
+  --ifm-color-primary-lighter: #32d8b4;
+  --ifm-color-primary-lightest: #4fddbf;
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,206 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Development environment setup script for Windows.
+
+.DESCRIPTION
+    Sets up the development environment for McjCoderOrg.ClaudeAutoResume.
+    Checks prerequisites, restores dependencies, configures git hooks, and verifies the build.
+
+.EXAMPLE
+    ./scripts/setup.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Status {
+    param([string]$Message)
+    Write-Host "[OK] $Message" -ForegroundColor Green
+}
+
+function Write-Checking {
+    param([string]$Message)
+    Write-Host "[..] $Message" -ForegroundColor Yellow -NoNewline
+}
+
+function Write-Error {
+    param([string]$Message)
+    Write-Host "[FAIL] $Message" -ForegroundColor Red
+}
+
+function Test-Command {
+    param([string]$Command)
+    $null -ne (Get-Command $Command -ErrorAction SilentlyContinue)
+}
+
+Write-Host ""
+Write-Host "McjCoderOrg.ClaudeAutoResume - Development Setup" -ForegroundColor Cyan
+Write-Host "=================================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Check prerequisites
+Write-Host "Checking prerequisites..." -ForegroundColor White
+Write-Host ""
+
+# Check .NET SDK
+Write-Checking ".NET SDK 10.0+: "
+if (Test-Command 'dotnet') {
+    $dotnetVersion = dotnet --version 2>$null
+    if ($dotnetVersion -match '^10\.') {
+        Write-Host ""
+        Write-Status ".NET SDK $dotnetVersion"
+    } else {
+        Write-Host ""
+        Write-Error ".NET SDK 10.0+ required, found $dotnetVersion"
+        Write-Host "  Install from: https://dotnet.microsoft.com/download/dotnet/10.0" -ForegroundColor Gray
+        exit 1
+    }
+} else {
+    Write-Host ""
+    Write-Error ".NET SDK not found"
+    Write-Host "  Install from: https://dotnet.microsoft.com/download/dotnet/10.0" -ForegroundColor Gray
+    exit 1
+}
+
+# Check Node.js
+Write-Checking "Node.js 22+: "
+if (Test-Command 'node') {
+    $nodeVersion = node --version 2>$null
+    $nodeMajor = [int]($nodeVersion -replace 'v(\d+)\..*', '$1')
+    if ($nodeMajor -ge 22) {
+        Write-Host ""
+        Write-Status "Node.js $nodeVersion"
+    } else {
+        Write-Host ""
+        Write-Error "Node.js 22+ required, found $nodeVersion"
+        Write-Host "  Install from: https://nodejs.org/" -ForegroundColor Gray
+        exit 1
+    }
+} else {
+    Write-Host ""
+    Write-Error "Node.js not found"
+    Write-Host "  Install from: https://nodejs.org/" -ForegroundColor Gray
+    exit 1
+}
+
+# Check Git
+Write-Checking "Git: "
+if (Test-Command 'git') {
+    $gitVersion = git --version 2>$null
+    Write-Host ""
+    Write-Status $gitVersion
+} else {
+    Write-Host ""
+    Write-Error "Git not found"
+    Write-Host "  Install from: https://git-scm.com/" -ForegroundColor Gray
+    exit 1
+}
+
+# Check GitHub CLI (optional)
+Write-Checking "GitHub CLI: "
+if (Test-Command 'gh') {
+    $ghVersion = gh --version 2>$null | Select-Object -First 1
+    Write-Host ""
+    Write-Status $ghVersion
+} else {
+    Write-Host ""
+    Write-Host "[SKIP] GitHub CLI not found (optional)" -ForegroundColor DarkGray
+    Write-Host "  Install from: https://cli.github.com/" -ForegroundColor Gray
+}
+
+Write-Host ""
+Write-Host "Installing dependencies..." -ForegroundColor White
+Write-Host ""
+
+# Install npm dependencies
+Write-Checking "npm install: "
+npm install --silent 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Status "npm packages installed"
+} else {
+    Write-Host ""
+    Write-Error "npm install failed"
+    exit 1
+}
+
+# Restore .NET dependencies
+Write-Checking "dotnet restore: "
+dotnet restore --verbosity quiet 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Status ".NET packages restored"
+} else {
+    Write-Host ""
+    Write-Error "dotnet restore failed"
+    exit 1
+}
+
+# Restore .NET tools
+Write-Checking "dotnet tool restore: "
+dotnet tool restore --verbosity quiet 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Status ".NET tools restored"
+} else {
+    Write-Host ""
+    Write-Error "dotnet tool restore failed"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Configuring git hooks..." -ForegroundColor White
+Write-Host ""
+
+# Configure git hooks via Husky
+Write-Checking "Husky hooks: "
+npx husky install 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Status "Git hooks configured"
+} else {
+    Write-Host ""
+    Write-Host "[SKIP] Husky install skipped (may already be configured)" -ForegroundColor DarkGray
+}
+
+Write-Host ""
+Write-Host "Verifying build..." -ForegroundColor White
+Write-Host ""
+
+# Build the solution
+Write-Checking "dotnet build: "
+dotnet build --verbosity quiet 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Status "Build successful"
+} else {
+    Write-Host ""
+    Write-Error "Build failed"
+    exit 1
+}
+
+# Run tests
+Write-Checking "dotnet test: "
+$testOutput = dotnet test --verbosity quiet --no-build 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Status "All tests passed"
+} else {
+    Write-Host ""
+    Write-Error "Tests failed"
+    Write-Host $testOutput -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "=================================================" -ForegroundColor Cyan
+Write-Host "Setup complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor White
+Write-Host "  1. Open the project in VS Code or Visual Studio" -ForegroundColor Gray
+Write-Host "  2. Read CONTRIBUTING.md for contribution guidelines" -ForegroundColor Gray
+Write-Host "  3. Check docs/ for project documentation" -ForegroundColor Gray
+Write-Host ""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Development environment setup script for Unix (Linux/macOS)
+#
+# Sets up the development environment for McjCoderOrg.ClaudeAutoResume.
+# Checks prerequisites, restores dependencies, configures git hooks, and verifies the build.
+#
+# Usage: ./scripts/setup.sh
+
+set -e
+
+# Colours
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+GRAY='\033[0;90m'
+NC='\033[0m' # No Colour
+
+write_status() {
+    echo -e "${GREEN}[OK]${NC} $1"
+}
+
+write_checking() {
+    echo -en "${YELLOW}[..]${NC} $1"
+}
+
+write_error() {
+    echo -e "${RED}[FAIL]${NC} $1"
+}
+
+write_skip() {
+    echo -e "${GRAY}[SKIP]${NC} $1"
+}
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+echo ""
+echo -e "${CYAN}McjCoderOrg.ClaudeAutoResume - Development Setup${NC}"
+echo -e "${CYAN}=================================================${NC}"
+echo ""
+
+# Check prerequisites
+echo -e "Checking prerequisites..."
+echo ""
+
+# Check .NET SDK
+write_checking ".NET SDK 10.0+: "
+if command_exists dotnet; then
+    DOTNET_VERSION=$(dotnet --version 2>/dev/null)
+    if [[ "$DOTNET_VERSION" =~ ^10\. ]]; then
+        echo ""
+        write_status ".NET SDK $DOTNET_VERSION"
+    else
+        echo ""
+        write_error ".NET SDK 10.0+ required, found $DOTNET_VERSION"
+        echo -e "  ${GRAY}Install from: https://dotnet.microsoft.com/download/dotnet/10.0${NC}"
+        exit 1
+    fi
+else
+    echo ""
+    write_error ".NET SDK not found"
+    echo -e "  ${GRAY}Install from: https://dotnet.microsoft.com/download/dotnet/10.0${NC}"
+    exit 1
+fi
+
+# Check Node.js
+write_checking "Node.js 22+: "
+if command_exists node; then
+    NODE_VERSION=$(node --version 2>/dev/null)
+    NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/v\([0-9]*\).*/\1/')
+    if [ "$NODE_MAJOR" -ge 22 ]; then
+        echo ""
+        write_status "Node.js $NODE_VERSION"
+    else
+        echo ""
+        write_error "Node.js 22+ required, found $NODE_VERSION"
+        echo -e "  ${GRAY}Install from: https://nodejs.org/${NC}"
+        exit 1
+    fi
+else
+    echo ""
+    write_error "Node.js not found"
+    echo -e "  ${GRAY}Install from: https://nodejs.org/${NC}"
+    exit 1
+fi
+
+# Check Git
+write_checking "Git: "
+if command_exists git; then
+    GIT_VERSION=$(git --version 2>/dev/null)
+    echo ""
+    write_status "$GIT_VERSION"
+else
+    echo ""
+    write_error "Git not found"
+    echo -e "  ${GRAY}Install from: https://git-scm.com/${NC}"
+    exit 1
+fi
+
+# Check GitHub CLI (optional)
+write_checking "GitHub CLI: "
+if command_exists gh; then
+    GH_VERSION=$(gh --version 2>/dev/null | head -1)
+    echo ""
+    write_status "$GH_VERSION"
+else
+    echo ""
+    write_skip "GitHub CLI not found (optional)"
+    echo -e "  ${GRAY}Install from: https://cli.github.com/${NC}"
+fi
+
+echo ""
+echo "Installing dependencies..."
+echo ""
+
+# Install npm dependencies
+write_checking "npm install: "
+if npm install --silent 2>/dev/null; then
+    echo ""
+    write_status "npm packages installed"
+else
+    echo ""
+    write_error "npm install failed"
+    exit 1
+fi
+
+# Restore .NET dependencies
+write_checking "dotnet restore: "
+if dotnet restore --verbosity quiet 2>/dev/null; then
+    echo ""
+    write_status ".NET packages restored"
+else
+    echo ""
+    write_error "dotnet restore failed"
+    exit 1
+fi
+
+# Restore .NET tools
+write_checking "dotnet tool restore: "
+if dotnet tool restore --verbosity quiet 2>/dev/null; then
+    echo ""
+    write_status ".NET tools restored"
+else
+    echo ""
+    write_error "dotnet tool restore failed"
+    exit 1
+fi
+
+echo ""
+echo "Configuring git hooks..."
+echo ""
+
+# Configure git hooks via Husky
+write_checking "Husky hooks: "
+if npx husky install 2>/dev/null; then
+    echo ""
+    write_status "Git hooks configured"
+else
+    echo ""
+    write_skip "Husky install skipped (may already be configured)"
+fi
+
+echo ""
+echo "Verifying build..."
+echo ""
+
+# Build the solution
+write_checking "dotnet build: "
+if dotnet build --verbosity quiet 2>/dev/null; then
+    echo ""
+    write_status "Build successful"
+else
+    echo ""
+    write_error "Build failed"
+    exit 1
+fi
+
+# Run tests
+write_checking "dotnet test: "
+if dotnet test --verbosity quiet --no-build 2>/dev/null; then
+    echo ""
+    write_status "All tests passed"
+else
+    echo ""
+    write_error "Tests failed"
+    exit 1
+fi
+
+echo ""
+echo -e "${CYAN}=================================================${NC}"
+echo -e "${GREEN}Setup complete!${NC}"
+echo ""
+echo "Next steps:"
+echo -e "  ${GRAY}1. Open the project in VS Code or Visual Studio${NC}"
+echo -e "  ${GRAY}2. Read CONTRIBUTING.md for contribution guidelines${NC}"
+echo -e "  ${GRAY}3. Check docs/ for project documentation${NC}"
+echo ""


### PR DESCRIPTION
## Summary

- Add `.devcontainer/devcontainer.json` for Dev Container support with .NET 10, Node.js 22, GitHub CLI, and VS Code extensions
- Add `scripts/setup.ps1` for Windows development environment setup
- Add `scripts/setup.sh` for Unix (Linux/macOS) development environment setup
- Initialize Docusaurus documentation site in `docs/docusaurus/`
- Add `.github/workflows/docs.yml` for GitHub Pages deployment
- Create initial documentation pages covering getting started, guides, contributing, and architecture

## Test plan

- [ ] Verify devcontainer.json is valid
- [ ] Verify setup scripts check prerequisites correctly
- [ ] Verify documentation site structure is complete
- [ ] Verify docs workflow deploys to GitHub Pages

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)