### PR TITLE
fix: handle detached head state in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -16,6 +16,14 @@ fi
 # Validate branch name format
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
+# Handle detached HEAD state (e.g., tag pushes, CI pipelines)
+# In detached HEAD, git rev-parse returns literal "HEAD"
+if [ "$branch" = "HEAD" ]; then
+  echo "Detached HEAD state detected - skipping branch name validation"
+  echo "(This is expected for tag pushes and CI pipelines)"
+  exit 0
+fi
+
 # Allow main branch pushes (for releases)
 if [ "$branch" = "main" ]; then
   exit 0


### PR DESCRIPTION
## Summary

Fixes the pre-push hook to handle detached HEAD state gracefully.

**Problem:** When in detached HEAD state (e.g., tag pushes, CI pipelines), `git rev-parse --abbrev-ref HEAD` returns literal "HEAD", causing the branch name validation to incorrectly fail for legitimate operations.

**Solution:** Detect detached HEAD state and allow the push to proceed with an informative message explaining why branch validation is skipped.

## Test plan

- [x] Verify normal branch pushes still validate correctly
- [ ] Verify detached HEAD state is detected and allowed
- [ ] Verify tag pushes work in detached HEAD state

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)