### PR TITLE
fix: improve cross-platform compatibility of git hooks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -42,7 +42,8 @@ fi
 echo "Branch name validation passed: $branch"
 
 # Run unit tests before push (if solution exists and dotnet is available)
-if find . -maxdepth 2 -name "*.sln" -print -quit 2>/dev/null | grep -q .; then
+# Note: Using head -1 instead of find -quit for macOS/BSD compatibility
+if find . -maxdepth 2 -name "*.sln" 2>/dev/null | head -1 | grep -q .; then
   if ! command -v dotnet >/dev/null 2>&1; then
     echo "Warning: dotnet not installed, skipping unit tests."
   else

--- a/docs/playbooks/troubleshooting/hook-issues.md
+++ b/docs/playbooks/troubleshooting/hook-issues.md
@@ -107,3 +107,76 @@ Refs: #42
 2. **Pushing to main directly**
    - Create a feature branch
    - Push to feature branch instead
+
+---
+
+## Problem: Hooks Fail on Windows
+
+**Symptoms:**
+
+- Hook script errors
+- Command not found errors
+- Path issues
+
+**Solutions:**
+
+1. **Use Git Bash (not PowerShell/CMD)**
+
+   Git hooks use shell scripts. On Windows, Git Bash provides the required
+   Unix-like environment:
+
+   ```bash
+   # Open Git Bash (not PowerShell)
+   # Run git commands from Git Bash terminal
+   ```
+
+2. **Line ending issues**
+
+   If hooks fail with cryptic errors, check line endings:
+
+   ```bash
+   # Ensure hooks have Unix line endings (LF, not CRLF)
+   git config core.autocrlf false
+
+   # Re-install hooks
+   npm install
+   npx husky install
+   ```
+
+3. **Emoji display issues**
+
+   Windows terminals may not display emojis correctly. This is cosmetic only
+   and doesn't affect hook functionality.
+
+4. **GPG signing on Windows**
+
+   Install GPG4Win and ensure it's in your PATH:
+
+   ```bash
+   # Verify GPG is available
+   gpg --version
+
+   # If not found, add GPG4Win to PATH or use:
+   git config --global gpg.program "C:/Program Files (x86)/GnuPG/bin/gpg.exe"
+   ```
+
+---
+
+## Cross-Platform Compatibility Notes
+
+The hook scripts are designed to work across:
+
+- **Linux**: bash
+- **macOS**: zsh/bash (BSD tools)
+- **Windows**: Git Bash (MinGW)
+
+**Known differences:**
+
+| Feature       | Linux/macOS        | Windows          |
+| ------------- | ------------------ | ---------------- |
+| Shell         | /bin/sh (bash/zsh) | Git Bash (MinGW) |
+| GPG           | gpg                | GPG4Win          |
+| Line endings  | LF                 | CRLF (converted) |
+| Emoji support | Full               | Limited          |
+
+If you encounter platform-specific issues not covered here, please open an issue


### PR DESCRIPTION
## Summary

Improves cross-platform compatibility of git hooks and adds documentation for Windows users.

**Changes:**

- Replace GNU-specific `find -quit` with portable `head -1` for macOS/BSD compatibility
- Add Windows-specific troubleshooting section to `docs/playbooks/troubleshooting/hook-issues.md`
- Document cross-platform compatibility notes and known differences
- Add GPG4Win configuration guidance for Windows users

## Test plan

- [x] Verify hooks work on Windows Git Bash
- [ ] Verify hooks work on macOS (BSD find)
- [ ] Verify hooks work on Linux

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)