### PR TITLE
feat: add branch name validation to pr workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: PR Title Validation
+name: PR Validation
 
 on:
   pull_request:
@@ -38,6 +38,31 @@ jobs:
           subjectPatternError: |
             The subject "{subject}" must start with a lowercase letter and not end with a period.
             Example: "feat: add user authentication"
+
+      - name: Validate branch name
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          echo "Validating branch name: $BRANCH_NAME"
+
+          # Allow main branch (shouldn't happen in PRs, but just in case)
+          if [ "$BRANCH_NAME" = "main" ]; then
+            echo "Main branch - allowed"
+            exit 0
+          fi
+
+          # Validate branch naming convention
+          # Valid patterns: feature/N-*, fix/N-*, docs/N-*, chore/N-*, refactor/N-*, test/N-*
+          if ! echo "$BRANCH_NAME" | grep -qE "^(feature|fix|docs|chore|refactor|test)/[0-9]+-"; then
+            echo "::error::Invalid branch name: $BRANCH_NAME"
+            echo ""
+            echo "Branch name must follow pattern: {type}/{issue#}-description"
+            echo "Valid types: feature, fix, docs, chore, refactor, test"
+            echo "Example: feature/123-add-login-page"
+            exit 1
+          fi
+
+          echo "Branch name validation passed"
 
       - name: Check issue reference
         env:


### PR DESCRIPTION
## Summary

Adds server-side branch naming validation as a safety net for when local pre-push hooks are bypassed with `--no-verify`.

**Changes:**

- Add branch name validation step to PR Validation workflow
- Validates pattern: `{type}/{issue#}-description`
- Provides clear error messages matching local hook behavior
- Rename workflow from "PR Title Validation" to "PR Validation"

This completes the CI enforcement for commit conventions:
- ✅ Commit message validation (wagoid/commitlint-github-action)
- ✅ PR title validation (amannn/action-semantic-pull-request)
- ✅ Branch name validation (new in this PR)

## Test plan

- [x] Verify branch name validation mirrors pre-push hook behavior
- [ ] Verify PR with invalid branch name fails validation
- [ ] Verify PR with valid branch name passes validation

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)