### PR TITLE
fix: enforce lowercase subject in pr title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,13 +30,13 @@ jobs:
             ci
             chore
             revert
-            deps
           requireScope: false
           disallowScopes: |
             wip
-          subjectPattern: ^[a-z].+[^.]$
+          subjectPattern: ^[a-z]([^A-Z]*[^.A-Z])?$
           subjectPatternError: |
-            The subject "{subject}" must start with a lowercase letter and not end with a period.
+            The subject "{subject}" must be entirely lowercase and not end with a period.
+            This matches commitlint's subject-case rule for squash merge commits.
             Example: "feat: add user authentication"
 
       - name: Validate branch name


### PR DESCRIPTION
## Summary

Fixes a gap in PR title validation that allowed uppercase letters in subjects. When PRs are squash-merged, the PR title becomes the commit message subject, which must comply with commitlint's `subject-case: lower-case` rule.

### Problem

PR #61 was merged with title "feat: add release preparation documentation and tooling (Phase 8)" which passed the old validation (only checked first char was lowercase), but the squash commit failed commitlint on main because "Phase" contains uppercase "P".

### Changes

- Updated `subjectPattern` from `^[a-z].+[^.]$` to `^[a-z]([^A-Z]*[^.A-Z])?$`
  - Now rejects any uppercase letters (A-Z) anywhere in subject
  - Still requires first character to be lowercase
  - Still rejects trailing periods
- Removed deprecated `deps` type (we use `build` for dependency updates)
- Updated error message to explain the full rule

### Test Plan

- [x] Pattern tested against various inputs:
  - "add feature" ✓ (valid)
  - "add Feature" ✗ (uppercase F)
  - "add feature." ✗ (trailing period)
  - "add feature (issue 123)" ✓ (valid)
  - "add feature (Phase 8)" ✗ (uppercase P)
  - "a" ✓ (single char valid)

Closes #72

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>