### PR TITLE
fix: add verification step to pre-commit lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "lint-staged": {
     "*.cs": [
       "dotnet format --include",
+      "dotnet format --verify-no-changes --include",
       "cspell --no-must-find-files"
     ],
     "*.md": [


### PR DESCRIPTION
## Summary

Adds `dotnet format --verify-no-changes --include` after the fix step in lint-staged to catch unfixable lint issues before they reach CI.

## Problem

The pre-commit hook was running `dotnet format --include` which tries to fix issues but exits with code 0 even when some issues (like IDE1006 naming rules) cannot be auto-fixed. This allowed commits with lint violations to pass locally but fail in CI.

## Solution

Add a verification step that runs after the fix:
```json
"*.cs": [
  "dotnet format --include",
  "dotnet format --verify-no-changes --include",  // NEW
  "cspell --no-must-find-files"
]
```

Now the pre-commit hook will:
1. Attempt to fix formatting issues
2. Verify no issues remain (fails if unfixable issues exist)
3. Check spelling

## Test plan
- [x] Commit passes when no lint issues
- [ ] Commit fails when unfixable lint issues exist (manual verification)

Closes: #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)