### PR TITLE
fix: allow dependabot branches and commits in ci validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -51,6 +51,12 @@ jobs:
             exit 0
           fi
 
+          # Allow dependabot branches
+          if echo "$BRANCH_NAME" | grep -qE "^dependabot/"; then
+            echo "Dependabot branch - allowed"
+            exit 0
+          fi
+
           # Validate branch naming convention
           # Valid patterns: feature/N-*, fix/N-*, docs/N-*, chore/N-*, refactor/N-*, test/N-*
           if ! echo "$BRANCH_NAME" | grep -qE "^(feature|fix|docs|chore|refactor|test)/[0-9]+-"; then

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,12 @@
 export default {
   extends: ['@commitlint/config-conventional'],
-  // Ignore auto-generated merge and revert commits
-  ignores: [(commit) => /^Merge\s/.test(commit) || /^Revert\s/.test(commit)],
+  // Ignore auto-generated merge, revert, and dependabot commits
+  ignores: [
+    (commit) =>
+      /^Merge\s/.test(commit) ||
+      /^Revert\s/.test(commit) ||
+      /Signed-off-by: dependabot\[bot\]/i.test(commit),
+  ],
   rules: {
     'type-enum': [
       2,


### PR DESCRIPTION
## Summary
- Add `dependabot/*` pattern to branch name validation whitelist in pr-title.yml
- Ignore commits signed by `dependabot[bot]` in commitlint config

## Test plan
- [ ] Verify existing dependabot PRs can now pass CI after rebase

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)