### PR TITLE
chore: add linters to cspell dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -165,7 +165,8 @@
     "mklink",
     "msbuild",
     "msdata",
-    "unlist"
+    "unlist",
+    "linters"
   ],
   "flagWords": [],
   "allowCompoundWords": true,


### PR DESCRIPTION
## Summary
- Add 'linters' to cspell dictionary to fix spelling check failures

## Test plan
- [ ] Verify cspell lint passes

Refs: #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)