### PR TITLE
chore: relax pr title validation for dependabot

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
+        # Skip subject case validation for dependabot PRs (they use "Bump" with uppercase)
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +40,27 @@ jobs:
             The subject "{subject}" must be entirely lowercase and not end with a period.
             This matches commitlint's subject-case rule for squash merge commits.
             Example: "feat: add user authentication"
+
+      - name: Validate dependabot PR title (relaxed)
+        # For dependabot PRs, only validate the type prefix, not subject case
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
 
       - name: Validate branch name
         env:


### PR DESCRIPTION
## Summary
- Skip subject case validation for dependabot[bot] actor
- Use relaxed validation that only checks type prefix for dependabot PRs

Dependabot uses "Bump" with uppercase B in PR titles, which conflicts with our lowercase subject rule.

## Test plan
- [ ] Verify dependabot PRs pass PR title validation after rebase

Refs: #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)