### PR TITLE
docs: add persona switching playbook and pr author check

### DIFF
--- a/.github/workflows/pr-author-check.yml
+++ b/.github/workflows/pr-author-check.yml
@@ -1,0 +1,79 @@
+name: PR Author Check
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  check-author:
+    name: Validate PR Author
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR author is a code owner
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          echo "PR Author: $PR_AUTHOR"
+          echo "Repo Owner: $REPO_OWNER"
+
+          # List of code owner accounts (add your owner accounts here)
+          CODE_OWNERS="martincjarvis"
+
+          # Check if PR author is a code owner
+          if echo "$CODE_OWNERS" | grep -qw "$PR_AUTHOR"; then
+            echo ""
+            echo "::warning::PR created by code owner account ($PR_AUTHOR)"
+            echo ""
+            echo "Best practice: Use a separate contributor account to create PRs."
+            echo "This ensures proper separation of duties and avoids approval deadlock."
+            echo ""
+            echo "See: docs/playbooks/persona-switching.md"
+            echo ""
+            # Warning only - don't fail the check
+            # To enforce, change to: exit 1
+          else
+            echo "PR author ($PR_AUTHOR) is not a code owner - OK"
+          fi
+
+      - name: Add reminder comment for code owner PRs
+        if: contains('martincjarvis', github.event.pull_request.user.login)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const body = `## Reminder: Code Owner PR
+
+            This PR was created by \`${author}\`, who is a code owner.
+
+            **Potential issue:** Code owners cannot approve their own PRs. This may cause approval deadlock if no other reviewers are available.
+
+            **Recommended workflow:**
+            1. Use a separate contributor account to create PRs
+            2. Use the code owner account only for reviews and approvals
+
+            See [docs/playbooks/persona-switching.md](../docs/playbooks/persona-switching.md) for setup instructions.
+
+            ---
+            *This is an automated reminder. If this PR requires admin bypass, please coordinate with repository administrators.*`;
+
+            // Check if we already commented
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('Reminder: Code Owner PR')
+            );
+
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }

--- a/docs/playbooks/persona-switching.md
+++ b/docs/playbooks/persona-switching.md
@@ -1,0 +1,232 @@
+# Playbook: Persona Switching for PR Workflows
+
+## Overview
+
+This playbook documents how to switch between GitHub personas to enforce separation of
+duties in PR workflows. This ensures compliance with the InnerSource role model where
+Contributors create PRs and Owners/Maintainers review them.
+
+## Why Persona Switching?
+
+GitHub prevents self-approval of PRs by design. When branch protection requires approvals,
+the PR author cannot approve their own PR. This creates a deadlock if the same account is
+used for both authoring and reviewing.
+
+**Solution:** Use separate GitHub accounts for different roles:
+
+| Role            | Account Purpose        | Actions                    |
+| --------------- | ---------------------- | -------------------------- |
+| **Contributor** | Create PRs, push code  | `git push`, `gh pr create` |
+| **Owner**       | Review, approve, merge | `gh pr review --approve`   |
+
+## Prerequisites
+
+- Two GitHub accounts with repository access
+- Both accounts authenticated via `gh auth login`
+- GPG keys configured for each account (for signed commits)
+
+## Step 1: Authenticate Multiple Accounts
+
+```bash
+# Login with first account (e.g., contributor)
+gh auth login
+
+# Login with second account (e.g., owner/reviewer)
+gh auth login
+```
+
+Verify both accounts are configured:
+
+```bash
+gh auth status
+```
+
+Expected output:
+
+```text
+github.com
+  ✓ Logged in to github.com account contributor-account (keyring)
+  - Active account: true
+  ...
+
+  ✓ Logged in to github.com account owner-account (keyring)
+  - Active account: false
+  ...
+```
+
+## Step 2: Configure Git Identities
+
+Each persona needs a distinct git identity for proper attribution.
+
+### Option A: Repository-Level Config (Recommended)
+
+Create identity configs for each persona:
+
+```bash
+# Create contributor identity
+git config --global alias.as-contributor '!git config user.name "Contributor Name" && git config user.email "contributor@example.com" && gh auth switch --user contributor-account'
+
+# Create owner identity
+git config --global alias.as-owner '!git config user.name "Owner Name" && git config user.email "owner@example.com" && gh auth switch --user owner-account'
+```
+
+Usage:
+
+```bash
+git as-contributor  # Switch to contributor persona
+git as-owner        # Switch to owner persona
+```
+
+### Option B: Manual Switching
+
+```bash
+# Switch to contributor
+git config user.name "Contributor Name"
+git config user.email "contributor@example.com"
+gh auth switch --user contributor-account
+
+# Switch to owner
+git config user.name "Owner Name"
+git config user.email "owner@example.com"
+gh auth switch --user owner-account
+```
+
+## Step 3: GPG Keys per Persona
+
+Each persona should have its own GPG key for signed commits.
+
+```bash
+# List keys for current persona
+gpg --list-secret-keys --keyid-format=long
+
+# Configure signing key for persona
+git config user.signingkey YOUR_PERSONA_KEY_ID
+```
+
+See [enable-signed-commits.md](enable-signed-commits.md) for full GPG setup.
+
+## Workflow Example
+
+### Creating a PR (as Contributor)
+
+```bash
+# 1. Switch to contributor persona
+gh auth switch --user contributor-account
+git config user.name "Contributor Name"
+git config user.email "contributor@example.com"
+
+# 2. Create branch and make changes
+git checkout -b feature/123-new-feature
+# ... make changes ...
+git add .
+git commit -m "feat: add new feature
+
+Refs: #123"
+
+# 3. Push and create PR
+git push -u origin feature/123-new-feature
+gh pr create --title "feat: add new feature" --body "..."
+```
+
+### Reviewing a PR (as Owner)
+
+```bash
+# 1. Switch to owner persona
+gh auth switch --user owner-account
+
+# 2. Review the PR
+gh pr view 123
+gh pr diff 123
+
+# 3. Approve (following role-specific format)
+gh pr review 123 --approve --body "## Tech Lead Review
+...
+"
+```
+
+### After Merge
+
+```bash
+# Switch back to contributor for next task
+gh auth switch --user contributor-account
+git checkout main
+git pull
+```
+
+## Verification
+
+Check current persona:
+
+```bash
+# GitHub CLI account
+gh auth status | grep "Active account: true" -A1
+
+# Git identity
+git config user.name
+git config user.email
+```
+
+## CI Enforcement
+
+A GitHub Actions workflow can warn when PR authors are code owners.
+See `.github/workflows/pr-author-check.yml` for implementation.
+
+## Troubleshooting
+
+### "Cannot approve your own pull request"
+
+You're using the same account that created the PR. Switch personas:
+
+```bash
+gh auth switch --user reviewer-account
+gh pr review 123 --approve
+```
+
+### Commits showing wrong author
+
+Git identity wasn't switched before committing:
+
+```bash
+# Check current identity
+git config user.name
+git config user.email
+
+# Fix last commit author
+git commit --amend --author="Correct Name <correct@email.com>"
+```
+
+### GPG signature shows wrong key
+
+Signing key doesn't match current persona:
+
+```bash
+# Check current signing key
+git config user.signingkey
+
+# Update to correct key
+git config user.signingkey CORRECT_KEY_ID
+
+# Re-sign last commit
+git commit --amend --no-edit -S
+```
+
+## Best Practices
+
+1. **Always verify persona** before creating commits or PRs
+2. **Use aliases** to reduce switching errors
+3. **Configure GPG** for each persona to ensure verified commits
+4. **Document account mappings** in team onboarding materials
+
+## Role Mapping
+
+| InnerSource Role | GitHub Actions          | Persona Type |
+| ---------------- | ----------------------- | ------------ |
+| Contributor      | Create PR, push commits | Author       |
+| Maintainer       | Review, request changes | Reviewer     |
+| Owner            | Approve, merge, admin   | Reviewer     |
+
+## See Also
+
+- [docs/standards/roles.md](../standards/roles.md) - Role definitions
+- [enable-signed-commits.md](enable-signed-commits.md) - GPG setup
+- [github-setup.md](github-setup.md) - Repository configuration

--- a/docs/standards/roles.md
+++ b/docs/standards/roles.md
@@ -42,6 +42,10 @@ approve but do not author PRs.
 **Exception:** Repository bootstrap or emergency fixes may require Owner to submit PRs, but these
 must be reviewed by another Owner or external reviewer before merge.
 
+**Implementation:** To enforce separation of duties, use separate GitHub accounts for Contributor
+and Owner/Maintainer roles. See [persona-switching.md](../playbooks/persona-switching.md) for
+setup instructions.
+
 ### Task Assignment by InnerSource Role
 
 | Task Type              | Assign To                 | Rationale                              |


### PR DESCRIPTION
## Summary

- Add comprehensive persona switching documentation for enforcing separation of duties
- Add CI workflow to warn when PRs are created by code owner accounts
- Update roles.md to reference the new playbook

## Changes

### New Files
- `docs/playbooks/persona-switching.md` - Complete guide for:
  - Setting up multiple GitHub accounts
  - Switching between personas with `gh auth switch`
  - Configuring git identity per persona
  - GPG key considerations
  - Workflow examples

- `.github/workflows/pr-author-check.yml` - CI enforcement:
  - Warns when PR author is a code owner
  - Adds reminder comment to affected PRs
  - Non-blocking to avoid breaking existing workflows

### Updated Files
- `docs/standards/roles.md` - Added reference to persona-switching playbook

## Test plan

- [x] All 127 tests pass locally
- [x] Documentation is properly formatted (prettier, markdownlint)
- [x] Spelling check passes (cspell)
- [ ] CI workflow validates correctly (will test on this PR)

Closes #73
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)