### PR TITLE
chore: remove redundant secretlint rule packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.3.1",
         "@commitlint/config-conventional": "^20.3.1",
-        "@secretlint/secretlint-rule-aws": "^11.3.0",
-        "@secretlint/secretlint-rule-gcp": "^11.3.0",
-        "@secretlint/secretlint-rule-npm": "^11.3.0",
         "@secretlint/secretlint-rule-preset-recommend": "^11.3.0",
-        "@secretlint/secretlint-rule-privatekey": "^11.3.0",
         "cspell": "^9.6.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
@@ -1120,68 +1116,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@secretlint/secretlint-rule-aws": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-aws/-/secretlint-rule-aws-11.3.0.tgz",
-      "integrity": "sha512-Z4HtBTlJx/CueKOSkOdoeh5HxXQGagsBtTKy5Oz1w3vFOTmfYpKrapJgrc1aFRRJk+aaq357EsOCrsvNYKqdfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@secretlint/types": "11.3.0",
-        "@textlint/regexp-string-matcher": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@secretlint/secretlint-rule-gcp": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-gcp/-/secretlint-rule-gcp-11.3.0.tgz",
-      "integrity": "sha512-GVj9hNO9n10Mt0fVpxAvCyIJzbGHCsBzpsflE3CyfxIyytBs0wCwNlpm2y7EBcONr1tdXuU7FZP/fALlmgtSFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@secretlint/types": "11.3.0",
-        "@textlint/regexp-string-matcher": "^2.0.2",
-        "node-forge": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@secretlint/secretlint-rule-npm": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-npm/-/secretlint-rule-npm-11.3.0.tgz",
-      "integrity": "sha512-OSgzBpOomv75U3a5OYbSkJfgywGKJ56X/DzqC0qXdcR+jokn/SovYR2xIZCM6fz5BzfGd1WmjO0aFTt3o1HLFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@secretlint/types": "11.3.0",
-        "@textlint/regexp-string-matcher": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@secretlint/secretlint-rule-preset-recommend": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-11.3.0.tgz",
       "integrity": "sha512-s+FHhtx5dSXSthpgVRQFLiK/nNkeKYh0Bxk6gFcKeWPbE9tCg8zDGGMfQqsUnxvfs6X+LRtEFt5vLnv4PPlnjg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@secretlint/secretlint-rule-privatekey": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-privatekey/-/secretlint-rule-privatekey-11.3.0.tgz",
-      "integrity": "sha512-MWgD62QGilY0bEIHeyUeExRvugw0UiLgn/MMfMemPRc7ML7tp59NgR2Bg6ohchRcdOWdYmukPdIJ0XNPWMl09A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@textlint/regexp-string-matcher": "^2.0.2"
-      },
       "engines": {
         "node": ">=20.0.0"
       }
@@ -1283,19 +1223,6 @@
       "integrity": "sha512-rqfouEhBEgZlR9umswWXXRBcmmSM28Trpr9b0duzgehKYVc7wSQCuQMagr6YBJa2NRMfRNinupusbJXMg0ij2A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@textlint/regexp-string-matcher": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-2.0.2.tgz",
-      "integrity": "sha512-OXLD9XRxMhd3S0LWuPHpiARQOI7z9tCOs0FsynccW2lmyZzHHFJ9/eR6kuK9xF459Qf+740qI5h+/0cx+NljzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "lodash.sortby": "^4.7.0",
-        "lodash.uniq": "^4.5.0",
-        "lodash.uniqwith": "^4.5.0"
-      }
     },
     "node_modules/@textlint/resolver": {
       "version": "15.5.0",
@@ -2329,19 +2256,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3098,13 +3012,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -3123,13 +3030,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3994,16 +3894,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
-    "@secretlint/secretlint-rule-aws": "^11.3.0",
-    "@secretlint/secretlint-rule-gcp": "^11.3.0",
-    "@secretlint/secretlint-rule-npm": "^11.3.0",
     "@secretlint/secretlint-rule-preset-recommend": "^11.3.0",
-    "@secretlint/secretlint-rule-privatekey": "^11.3.0",
     "cspell": "^9.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",


### PR DESCRIPTION
## Summary

Remove redundant secretlint rule packages that are already included in the preset.

## Changes

Removed from package.json:
- `@secretlint/secretlint-rule-aws`
- `@secretlint/secretlint-rule-gcp`
- `@secretlint/secretlint-rule-npm`
- `@secretlint/secretlint-rule-privatekey`

These are already bundled in `@secretlint/secretlint-rule-preset-recommend` which is the only rule configured in `.secretlintrc.json`.

## Test plan

- [x] `npm run lint:secrets` works correctly
- [x] All tests pass locally

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)