### PR TITLE
docs: add git hook edge cases and limitations

### DIFF
--- a/docs/playbooks/troubleshooting/hook-issues.md
+++ b/docs/playbooks/troubleshooting/hook-issues.md
@@ -180,3 +180,211 @@ The hook scripts are designed to work across:
 | Emoji support | Full               | Limited          |
 
 If you encounter platform-specific issues not covered here, please open an issue
+
+---
+
+## Edge Cases and Limitations
+
+### Binary File Handling
+
+Hooks that run `prettier` or `dotnet format` skip binary files automatically.
+
+**Behaviour:**
+
+- Binary files are detected by file extension and content
+- lint-staged ignores binaries in its pattern matching
+- No special handling needed for images, executables, or archives
+
+**If binary files cause issues:**
+
+```bash
+# Check if file is being incorrectly processed
+git ls-files --stage | grep <filename>
+
+# Force-add binary to .gitattributes if needed
+echo "*.dat binary" >> .gitattributes
+```
+
+---
+
+### Git LFS Compatibility
+
+Git hooks work with Git LFS-tracked files with some considerations.
+
+**Behaviour:**
+
+- Pre-commit hooks see LFS pointer files, not actual content
+- lint-staged processes staged pointer files (small text files)
+- secretlint scans pointer content, not actual file content
+
+**Limitations:**
+
+- Secret scanning won't detect secrets in LFS-tracked files
+- Format checking doesn't apply to LFS content
+
+**Recommendation:**
+
+Don't track files containing secrets with Git LFS. Use environment
+variables or secrets management instead.
+
+---
+
+### Submodule Behaviour
+
+Hooks run only in the parent repository, not in submodules.
+
+**Behaviour:**
+
+- Submodule commits trigger hooks in the submodule directory
+- Parent repo commits involving submodule pointer updates run parent hooks
+- Each submodule must have its own hook configuration
+
+**Limitation:**
+
+Submodule changes are not validated by parent repository hooks. Each
+submodule is responsible for its own commit validation.
+
+---
+
+### Interactive Rebase Operations
+
+During `git rebase -i`, hooks behave differently.
+
+**Pre-commit hook:**
+
+- Runs for `reword`, `edit`, and `squash` operations
+- Does NOT run for `pick` (commits are replayed as-is)
+- May block rebase if branch protection triggers
+
+**Workaround for rebasing onto main:**
+
+```bash
+# Temporarily disable branch check during rebase
+GIT_REFLOG_ACTION=rebase git rebase origin/main
+
+# Or skip hooks during rebase (use cautiously)
+git rebase -i --no-verify origin/main
+```
+
+**Commit-msg hook:**
+
+- Runs for `reword` and `squash` operations
+- Original commit messages must be re-validated
+- May need to add `Refs: #X` to rebased commits
+
+---
+
+### Empty Commit Handling
+
+Empty commits (no file changes) have special behaviour.
+
+**Pre-commit hook:**
+
+- lint-staged has no files to process (succeeds silently)
+- Branch protection still blocks main branch commits
+
+**Commit-msg hook:**
+
+- Still validates commit message format
+- Still requires work item reference
+
+**Creating empty commits:**
+
+```bash
+# Empty commits are allowed with explicit flag
+git commit --allow-empty -m "chore: trigger ci rebuild
+
+Refs: #123"
+```
+
+---
+
+### Bypassing Hooks (`--no-verify`)
+
+The `--no-verify` flag skips all local hooks.
+
+**When to use:**
+
+- Emergency production fixes (CI will still validate)
+- Merge commits created by Git (hooks auto-skip these)
+- Recovery from hook infrastructure issues
+
+**When NOT to use:**
+
+- To avoid fixing commit message format
+- To skip tests that are failing
+- As a regular workflow habit
+
+**Audit trail:**
+
+Commits that bypassed hooks are still validated by CI. PRs from bypassed
+commits may fail required status checks.
+
+```bash
+# Emergency bypass example
+git commit --no-verify -m "emergency: fix critical production bug
+
+Refs: #999"
+
+# CI will still run all validations on push
+```
+
+**Preventing abuse:**
+
+Branch protection rules require CI status checks to pass before merge.
+Bypassing local hooks doesn't bypass CI enforcement.
+
+---
+
+### Merge Commit Handling
+
+Merge commits receive special treatment.
+
+**Automatic merge commits:**
+
+- Created by `git merge`, `git pull`, or GitHub merge button
+- commit-msg hook auto-detects and skips validation
+- Pattern: message starts with "Merge" keyword
+
+**Manual merge commits:**
+
+- If you edit a merge commit message, validation applies
+- Must follow conventional commits format if edited
+
+**Fast-forward merges:**
+
+- No merge commit created
+- Original commit messages preserved
+- Original commits already validated
+
+---
+
+### Stash Operations
+
+Stashing does not trigger hooks.
+
+**Behaviour:**
+
+- `git stash` and `git stash pop` bypass hooks entirely
+- Stash messages don't follow conventional commits (expected)
+- Restored changes must pass hooks when committed
+
+---
+
+### Worktree Considerations
+
+Git worktrees share hooks with the main repository.
+
+**Behaviour:**
+
+- `.husky/` hooks apply to all worktrees
+- `node_modules/` must exist in each worktree
+- Each worktree may need `npm install`
+
+**Setup for new worktree:**
+
+```bash
+git worktree add ../feature-work feature/123-new-feature
+cd ../feature-work
+npm install  # Required for hooks to work
+```


### PR DESCRIPTION
## Summary
- Adds comprehensive documentation for git hook edge cases and limitations
- Covers binary file handling, Git LFS compatibility, submodule behaviour
- Documents interactive rebase, empty commit, and merge commit handling
- Provides clear guidance on `--no-verify` bypass usage
- Documents stash operations and worktree considerations

## Test plan
- [ ] Verify markdown renders correctly
- [ ] Confirm edge cases align with actual hook behaviour
- [ ] Review guidance is actionable for developers

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)