### PR TITLE
fix(csproj): remove duplicate publicapi file references

### DIFF
--- a/src/McjCoderOrg.ClaudeAutoResume/McjCoderOrg.ClaudeAutoResume.csproj
+++ b/src/McjCoderOrg.ClaudeAutoResume/McjCoderOrg.ClaudeAutoResume.csproj
@@ -59,12 +59,6 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <!-- Public API Tracking Files -->
-  <ItemGroup>
-    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
-    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
-  </ItemGroup>
-
   <!-- Resource Files -->
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.resx">


### PR DESCRIPTION
## Summary
- Remove explicit `<AdditionalFiles>` entries for `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt`
- The `Microsoft.CodeAnalysis.PublicApiAnalyzers` package automatically includes these files
- Eliminates "Duplicate source file" warnings during `dotnet format --verbosity diagnostic`

## Test plan
- [x] `dotnet format --verbosity diagnostic` runs without warnings
- [x] Build succeeds with 0 warnings
- [x] All tests pass (127 total)

Closes: #101

:robot: Generated with [Claude Code](https://claude.com/claude-code)