### PR TITLE
fix: return exit code 4 when claude cli is not found

### DIFF
--- a/src/McjCoderOrg.ClaudeAutoResume/ClaudeMonitor.cs
+++ b/src/McjCoderOrg.ClaudeAutoResume/ClaudeMonitor.cs
@@ -46,8 +46,8 @@ internal sealed class ClaudeMonitor : IDisposable
     /// Runs the Claude monitor with the specified additional arguments.
     /// </summary>
     /// <param name="additionalArgs">Additional arguments to pass to Claude.</param>
-    /// <returns>A task representing the async operation.</returns>
-    public async Task RunAsync(IReadOnlyList<string> additionalArgs)
+    /// <returns>True if claude was found and executed; false if claude was not found.</returns>
+    public async Task<bool> RunAsync(IReadOnlyList<string> additionalArgs)
     {
         _cts = new CancellationTokenSource();
         SetupCancellationHandler();
@@ -57,10 +57,11 @@ internal sealed class ClaudeMonitor : IDisposable
         {
             _logger.Error("Could not find 'claude' in PATH");
             WriteErrorLine("[claude-auto-resume] Error: Could not find 'claude' in PATH");
-            return;
+            return false;
         }
 
         await SpawnAndMonitorAsync(claudePath, additionalArgs).ConfigureAwait(false);
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/McjCoderOrg.ClaudeAutoResume/Program.cs
+++ b/src/McjCoderOrg.ClaudeAutoResume/Program.cs
@@ -109,9 +109,9 @@ internal static class Program
         PrintStartupInfo(config, parseResult.Headless, parseResult.Dangerous);
 
         using var monitor = new ClaudeMonitor(config);
-        await monitor.RunAsync(parseResult.ClaudeArgs).ConfigureAwait(false);
+        var claudeFound = await monitor.RunAsync(parseResult.ClaudeArgs).ConfigureAwait(false);
 
-        return ExitCodes.Success;
+        return claudeFound ? ExitCodes.Success : ExitCodes.DependencyMissing;
     }
 
     private sealed record ParseResult

--- a/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/ApplicationStartupTests.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/ApplicationStartupTests.cs
@@ -128,9 +128,12 @@ public sealed class ApplicationStartupTests
         }
         else
         {
-            // Process exited - either success or dependency missing
-            process.ExitCode.Should().BeOneOf([0, 4],
-                "exit code should be Success (0) or DependencyMissing (4)");
+            // Process exited quickly - claude CLI was not found
+            var errorOutput = await process.StandardError.ReadToEndAsync();
+            process.ExitCode.Should().Be(4,
+                "exit code should be DependencyMissing (4) when claude is not found");
+            errorOutput.Should().Contain("Could not find 'claude' in PATH",
+                "error output should indicate claude was not found");
         }
     }
 


### PR DESCRIPTION
## Summary
- `ClaudeMonitor.RunAsync` now returns bool indicating success/failure
- `Program.cs` returns `ExitCodes.DependencyMissing` (4) when claude not found
- E2E test now specifically expects exit code 4 (not 0 or 4)

## Root Cause
The previous implementation silently returned 0 even when claude was missing, which masked the dependency error. The E2E test accepted both exit codes (`BeOneOf([0, 4])`), so it didn't catch this bug.

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (63 tests)
- [x] E2E tests pass (5 tests)
- [x] Manual verification: app returns exit code 4 when claude not found

Closes: #103

:robot: Generated with [Claude Code](https://claude.com/claude-code)