### PR TITLE
fix: add category tags so pre-push filter excludes slow tests

### DIFF
--- a/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/ApplicationStartupTests.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/ApplicationStartupTests.cs
@@ -6,6 +6,7 @@ namespace McjCoderOrg.ClaudeAutoResume.E2ETests;
 /// End-to-end tests verifying the application starts correctly.
 /// These tests run the actual executable as a black-box test.
 /// </summary>
+[Trait("Category", "E2E")]
 public sealed class ApplicationStartupTests
 {
     private static readonly string _executablePath = Get_executablePath();

--- a/tests/McjCoderOrg.HookTests/Features/CommitMsgHook.feature
+++ b/tests/McjCoderOrg.HookTests/Features/CommitMsgHook.feature
@@ -1,4 +1,4 @@
-@commit-msg
+@commit-msg @Integration
 Feature: Commit message validation
     As a developer
     I want commit messages validated against conventions

--- a/tests/McjCoderOrg.HookTests/Features/CommitMsgHook.feature.cs
+++ b/tests/McjCoderOrg.HookTests/Features/CommitMsgHook.feature.cs
@@ -18,13 +18,15 @@ namespace McjCoderOrg.HookTests.Features
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "3.0.0.0")]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::Xunit.TraitAttribute("Category", "commit-msg")]
+    [global::Xunit.TraitAttribute("Category", "Integration")]
     public partial class CommitMessageValidationFeature : object, global::Xunit.IClassFixture<CommitMessageValidationFeature.FixtureData>, global::Xunit.IAsyncLifetime
     {
         
         private global::Reqnroll.ITestRunner testRunner;
         
         private static string[] featureTags = new string[] {
-                "commit-msg"};
+                "commit-msg",
+                "Integration"};
         
         private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "Commit message validation", "    As a developer\r\n    I want commit messages validated against conventions\r\n   " +
                 " So that changelog generation and traceability work correctly", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());

--- a/tests/McjCoderOrg.HookTests/Features/PreCommitHook.feature
+++ b/tests/McjCoderOrg.HookTests/Features/PreCommitHook.feature
@@ -1,4 +1,4 @@
-@pre-commit
+@pre-commit @Integration
 Feature: Pre-commit hook validation
     As a developer
     I want the pre-commit hook to enforce quality standards

--- a/tests/McjCoderOrg.HookTests/Features/PreCommitHook.feature.cs
+++ b/tests/McjCoderOrg.HookTests/Features/PreCommitHook.feature.cs
@@ -18,13 +18,15 @@ namespace McjCoderOrg.HookTests.Features
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "3.0.0.0")]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::Xunit.TraitAttribute("Category", "pre-commit")]
+    [global::Xunit.TraitAttribute("Category", "Integration")]
     public partial class Pre_CommitHookValidationFeature : object, global::Xunit.IClassFixture<Pre_CommitHookValidationFeature.FixtureData>, global::Xunit.IAsyncLifetime
     {
         
         private global::Reqnroll.ITestRunner testRunner;
         
         private static string[] featureTags = new string[] {
-                "pre-commit"};
+                "pre-commit",
+                "Integration"};
         
         private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "Pre-commit hook validation", "    As a developer\r\n    I want the pre-commit hook to enforce quality standards\r\n" +
                 "    So that code quality is maintained before commits", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());

--- a/tests/McjCoderOrg.HookTests/Features/PrePushHook.feature
+++ b/tests/McjCoderOrg.HookTests/Features/PrePushHook.feature
@@ -1,4 +1,4 @@
-@pre-push
+@pre-push @Integration
 Feature: Pre-push hook validation
     As a developer
     I want branch naming and tests validated before push

--- a/tests/McjCoderOrg.HookTests/Features/PrePushHook.feature.cs
+++ b/tests/McjCoderOrg.HookTests/Features/PrePushHook.feature.cs
@@ -18,13 +18,15 @@ namespace McjCoderOrg.HookTests.Features
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Reqnroll", "3.0.0.0")]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::Xunit.TraitAttribute("Category", "pre-push")]
+    [global::Xunit.TraitAttribute("Category", "Integration")]
     public partial class Pre_PushHookValidationFeature : object, global::Xunit.IClassFixture<Pre_PushHookValidationFeature.FixtureData>, global::Xunit.IAsyncLifetime
     {
         
         private global::Reqnroll.ITestRunner testRunner;
         
         private static string[] featureTags = new string[] {
-                "pre-push"};
+                "pre-push",
+                "Integration"};
         
         private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features", "Pre-push hook validation", "    As a developer\r\n    I want branch naming and tests validated before push\r\n   " +
                 " So that the remote repository maintains quality standards", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());


### PR DESCRIPTION
## Summary
- Add `[Trait("Category", "E2E")]` to ApplicationStartupTests class
- Add `@Integration` tag to all HookTests feature files
- This enables the pre-push hook filter `Category!=Integration&Category!=E2E` to correctly exclude slow tests

## Before
Pre-push ran ALL tests (~60 seconds including HookTests)

## After  
Pre-push runs only fast unit tests (~200ms)

## Test plan
- [x] Verified filter excludes E2ETests: "No test matches the given testcase filter"
- [x] Verified filter excludes HookTests: "No test matches the given testcase filter"
- [x] Fast tests still run and pass (89 tests in ~200ms)

Refs: #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)