### PR TITLE
feat(e2e): add happy path exit test infrastructure and piped stdin support

### DIFF
--- a/src/McjCoderOrg.ClaudeAutoResume/ClaudeMonitor.cs
+++ b/src/McjCoderOrg.ClaudeAutoResume/ClaudeMonitor.cs
@@ -359,6 +359,40 @@ internal sealed class ClaudeMonitor : IDisposable
     {
         var stream = _pty!.WriterStream;
 
+        if (Console.IsInputRedirected)
+        {
+            await ForwardPipedInputAsync(stream, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            await ForwardInteractiveInputAsync(stream, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ForwardPipedInputAsync(Stream stream, CancellationToken ct)
+    {
+        // Read lines from piped stdin and forward to PTY
+        // Use Console.In which is already configured as the stdin TextReader
+        var reader = Console.In;
+
+        while (!ct.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+            if (line == null)
+            {
+                // EOF reached
+                break;
+            }
+
+            // Send line followed by carriage return to simulate Enter keypress
+            var bytes = Encoding.UTF8.GetBytes(line + "\r\n");
+            await stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ForwardInteractiveInputAsync(Stream stream, CancellationToken ct)
+    {
         while (!ct.IsCancellationRequested)
         {
             var key = await Task.Run(

--- a/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/Features/ApplicationStartup.feature
+++ b/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/Features/ApplicationStartup.feature
@@ -44,3 +44,17 @@ Feature: Application startup
         And claude CLI is available
         When I run the application with no arguments
         Then the application should keep running for at least 3 seconds
+
+    # NOTE: This test requires manual execution - Claude Code's input handler
+    # doesn't execute commands from piped stdin the same way as interactive input.
+    # The piped stdin support is implemented but Claude Code's PTY input handling
+    # requires further investigation to fully support automated /exit testing.
+    @happy-path @skip-if-claude-missing @manual
+    Scenario: Exit cleanly via /exit command
+        Given the executable exists
+        And claude CLI is available
+        When I start the application interactively
+        And I wait for the application to be ready
+        And I send "/exit" to the application
+        Then the application should exit within 30 seconds
+        And the exit code should be 0

--- a/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/Features/ApplicationStartup.feature.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/Features/ApplicationStartup.feature.cs
@@ -108,7 +108,7 @@ namespace McjCoderOrg.ClaudeAutoResume.E2ETests.Features
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Features/ApplicationStartup.feature.ndjson", 8);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Features/ApplicationStartup.feature.ndjson", 9);
         }
         
         async global::System.Threading.Tasks.Task global::Xunit.IAsyncLifetime.InitializeAsync()
@@ -366,6 +366,58 @@ namespace McjCoderOrg.ClaudeAutoResume.E2ETests.Features
 #line hidden
 #line 46
         await testRunner.ThenAsync("the application should keep running for at least 3 seconds", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.SkippableFactAttribute(DisplayName="Exit cleanly via /exit command")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Application startup")]
+        [global::Xunit.TraitAttribute("Description", "Exit cleanly via /exit command")]
+        [global::Xunit.TraitAttribute("Category", "happy-path")]
+        [global::Xunit.TraitAttribute("Category", "skip-if-claude-missing")]
+        [global::Xunit.TraitAttribute("Category", "manual")]
+        public async global::System.Threading.Tasks.Task ExitCleanlyViaExitCommand()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "happy-path",
+                    "skip-if-claude-missing",
+                    "manual"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "6";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Exit cleanly via /exit command", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 53
+    this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 54
+        await testRunner.GivenAsync("the executable exists", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 55
+        await testRunner.AndAsync("claude CLI is available", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 56
+        await testRunner.WhenAsync("I start the application interactively", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 57
+        await testRunner.AndAsync("I wait for the application to be ready", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 58
+        await testRunner.AndAsync("I send \"/exit\" to the application", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 59
+        await testRunner.ThenAsync("the application should exit within 30 seconds", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+#line 60
+        await testRunner.AndAsync("the exit code should be 0", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();

--- a/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/StepDefinitions/ApplicationStartupSteps.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.E2ETests/StepDefinitions/ApplicationStartupSteps.cs
@@ -114,6 +114,128 @@ public sealed class ApplicationStartupSteps : IDisposable
         }
     }
 
+    [When("I start the application interactively")]
+    public void WhenIStartTheApplicationInteractively()
+    {
+        _process = ProcessHelper.CreateProcess(string.Empty);
+        _process.Start();
+    }
+
+    [When("I wait for the application to be ready")]
+    public async Task WhenIWaitForTheApplicationToBeReady()
+    {
+        if (_process is null)
+        {
+            throw new InvalidOperationException("Process not started");
+        }
+
+        // Wait for Claude to initialize - look for the prompt indicator
+        // Claude Code shows a prompt like "❯" when ready
+        var output = new System.Text.StringBuilder();
+        var timeout = TimeSpan.FromSeconds(60);
+        using var cts = new CancellationTokenSource(timeout);
+
+        try
+        {
+            // Start reading output in background
+            var readTask = ReadOutputUntilReadyAsync(_process, output, cts.Token);
+            await readTask.ConfigureAwait(false);
+
+            // Give Claude time to fully initialize its input handling
+            // Claude takes a few seconds after showing the banner to be ready for input
+            await Task.Delay(3000).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail(string.Format(
+                CultureInfo.InvariantCulture,
+                "Timeout waiting for application to be ready. Output so far: {0}",
+                output.ToString()));
+        }
+    }
+
+    private static async Task ReadOutputUntilReadyAsync(Process process, System.Text.StringBuilder output, CancellationToken ct)
+    {
+        var buffer = new char[4096];
+
+        while (!ct.IsCancellationRequested)
+        {
+            var bytesRead = await process.StandardOutput.ReadAsync(buffer.AsMemory(), ct).ConfigureAwait(false);
+
+            if (bytesRead > 0)
+            {
+                output.Append(buffer, 0, bytesRead);
+                var outputStr = output.ToString();
+
+                // Check for Claude prompt indicator (❯) or other ready signals
+                // Also check for "Claude Code" banner which indicates Claude started
+                if (outputStr.Contains('❯', StringComparison.Ordinal) ||
+                    outputStr.Contains("Claude Code", StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+
+            // Check if process exited unexpectedly
+            if (process.HasExited)
+            {
+                var stderr = await process.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
+                Assert.Fail(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Application exited unexpectedly during startup with code {0}. Output: {1} Error: {2}",
+                    process.ExitCode,
+                    output.ToString(),
+                    stderr));
+            }
+        }
+    }
+
+    [When("I send {string} to the application")]
+    public async Task WhenISendToTheApplication(string input)
+    {
+        if (_process is null)
+        {
+            throw new InvalidOperationException("Process not started");
+        }
+
+        await _process.StandardInput.WriteLineAsync(input).ConfigureAwait(false);
+        await _process.StandardInput.FlushAsync().ConfigureAwait(false);
+
+        // Give the command time to be processed before closing stdin
+        await Task.Delay(1000).ConfigureAwait(false);
+
+        // Close stdin after sending command - this signals EOF which may help
+        // the application detect input completion
+        _process.StandardInput.Close();
+    }
+
+    [Then("the application should exit within {int} seconds")]
+    public async Task ThenTheApplicationShouldExitWithinSeconds(int seconds)
+    {
+        if (_process is null)
+        {
+            throw new InvalidOperationException("Process not started");
+        }
+
+        var exitTask = _process.WaitForExitAsync();
+        var timeoutTask = Task.Delay(TimeSpan.FromSeconds(seconds));
+
+        var completedTask = await Task.WhenAny(exitTask, timeoutTask).ConfigureAwait(false);
+
+        if (completedTask == timeoutTask)
+        {
+            _process.Kill();
+            Assert.Fail(string.Format(
+                CultureInfo.InvariantCulture,
+                "Application did not exit within {0} seconds",
+                seconds));
+        }
+
+        var stdout = await _process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+        var stderr = await _process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+        _result = new ProcessResult(_process.ExitCode, stdout, stderr);
+    }
+
     private ProcessResult Result => _result ?? throw new InvalidOperationException("No process result available");
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- Add piped stdin support to ClaudeMonitor for non-interactive testing
- Add test scenario and step definitions for /exit command happy path
- Add ReadOutputUntilReadyAsync helper for detecting Claude readiness

## Known Limitations
The /exit test is marked `@manual` as Claude Code's PTY input handler doesn't execute commands from piped stdin the same way as interactive input. The text IS being sent to Claude (visible in output), but the Enter keypress isn't being processed to execute the command. Further investigation needed for full automation.

## Test plan
- [x] Existing CLI flag tests pass (--version, --help, --diagnose, --headless)
- [x] Pre-push hook runs successfully (62 unit tests, 4 arch tests, 22 system tests)
- [x] Manual test shows /exit command is sent to Claude (but Enter not executed)

Refs #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)