### PR TITLE
fix(docs): correct adr link in dependency injection standards

### DIFF
--- a/docs/standards/coding-standards/dependency-injection.md
+++ b/docs/standards/coding-standards/dependency-injection.md
@@ -264,4 +264,4 @@ Log.Logger = new LoggerConfiguration()
 ## Related
 
 - [Microsoft DI Documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection)
-- [ADR-0022: Dependency Injection Foundation](../adr/0022-dependency-injection-foundation.md)
+- [ADR-0032: Dependency Injection Foundation](../../adr/0032-dependency-injection-foundation.md)


### PR DESCRIPTION
## Summary
- Fixes broken link to ADR-0032 (was incorrectly referencing ADR-0022)
- Corrects relative path from `coding-standards/` subdirectory

## Test plan
- [ ] Link resolves correctly in documentation

Refs: #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)