### PR TITLE
fix: resolve analyzer errors in test mocks and add proxy assembly visibility

### DIFF
--- a/docs/standards/coding-standards/dependency-injection.md
+++ b/docs/standards/coding-standards/dependency-injection.md
@@ -264,4 +264,4 @@ Log.Logger = new LoggerConfiguration()
 ## Related
 
 - [Microsoft DI Documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection)
-- [ADR-0022: Dependency Injection Foundation](../adr/0022-dependency-injection-foundation.md)
+- [ADR-0032: Dependency Injection Foundation](../../adr/0032-dependency-injection-foundation.md)

--- a/src/McjCoderOrg.ClaudeAutoResume/McjCoderOrg.ClaudeAutoResume.csproj
+++ b/src/McjCoderOrg.ClaudeAutoResume/McjCoderOrg.ClaudeAutoResume.csproj
@@ -29,6 +29,7 @@
     <InternalsVisibleTo Include="McjCoderOrg.ClaudeAutoResume.Tests" />
     <InternalsVisibleTo Include="McjCoderOrg.ClaudeAutoResume.SystemTests" />
     <InternalsVisibleTo Include="McjCoderOrg.ClaudeAutoResume.ArchTests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <!-- Public API Analyzer -->

--- a/tests/McjCoderOrg.ClaudeAutoResume.Tests/ClaudeMonitorTests.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.Tests/ClaudeMonitorTests.cs
@@ -13,14 +13,14 @@ public sealed class ClaudeMonitorTests : IDisposable
     public ClaudeMonitorTests(ITestOutputHelper output)
     {
         _output = output;
-        _mockConsole = new Mock<IConsoleService>();
-        _mockEnvironment = new Mock<IEnvironmentService>();
+        _mockConsole = new Mock<IConsoleService>(MockBehavior.Loose);
+        _mockEnvironment = new Mock<IEnvironmentService>(MockBehavior.Loose);
 
         // Setup default mock behavior
         _mockConsole.Setup(c => c.WindowWidth).Returns(120);
         _mockConsole.Setup(c => c.WindowHeight).Returns(30);
         _mockEnvironment.Setup(e => e.CurrentDirectory).Returns(Environment.CurrentDirectory);
-        _mockEnvironment.Setup(e => e.GetEnvironmentVariables()).Returns(new Dictionary<string, string>());
+        _mockEnvironment.Setup(e => e.GetEnvironmentVariables()).Returns(new Dictionary<string, string>(StringComparer.Ordinal));
 
         _monitor = new ClaudeMonitor(WrapperConfig.Default, _mockConsole.Object, _mockEnvironment.Object);
         _output.WriteLine("ClaudeMonitorTests initialized with default config and mock services");

--- a/tests/McjCoderOrg.ClaudeAutoResume.Tests/ProgramTests.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.Tests/ProgramTests.cs
@@ -16,8 +16,8 @@ public sealed class ProgramTests
     public ProgramTests(ITestOutputHelper output)
     {
         _output = output;
-        _mockConsole = new Mock<IConsoleService>();
-        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockConsole = new Mock<IConsoleService>(MockBehavior.Loose);
+        _mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Loose);
 
         // Setup console mock
         _mockConsole.Setup(c => c.WindowWidth).Returns(120);
@@ -26,9 +26,9 @@ public sealed class ProgramTests
 
     private Application CreateApplication(Mock<IArgumentParser>? parserMock = null)
     {
-        var mockEnvironment = new Mock<IEnvironmentService>();
+        var mockEnvironment = new Mock<IEnvironmentService>(MockBehavior.Loose);
         mockEnvironment.Setup(e => e.CurrentDirectory).Returns(Environment.CurrentDirectory);
-        mockEnvironment.Setup(e => e.GetEnvironmentVariables()).Returns(new Dictionary<string, string>());
+        mockEnvironment.Setup(e => e.GetEnvironmentVariables()).Returns(new Dictionary<string, string>(StringComparer.Ordinal));
 
         var parser = parserMock?.Object ?? new ArgumentParser(mockEnvironment.Object);
 
@@ -91,7 +91,7 @@ public sealed class ProgramTests
 
         _output.WriteLine("Exit code: {0} (expected: {1})", result, ExitCodes.InvalidArguments);
         result.Should().Be(ExitCodes.InvalidArguments);
-        _mockConsole.Verify(c => c.ForegroundColor = ConsoleColor.Red, Times.AtLeastOnce);
+        _mockConsole.VerifySet(c => c.ForegroundColor = ConsoleColor.Red, Times.AtLeastOnce);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `MockBehavior.Loose` to all Mock constructors (satisfies Moq1400 analyzer)
- Adds `StringComparer.Ordinal` to Dictionary constructors (satisfies MA0002 analyzer)
- Adds `DynamicProxyGenAssembly2` to `InternalsVisibleTo` for Moq proxy generation on internal interfaces
- Uses `VerifySet` for property setter verification
- Fixes broken ADR link in dependency-injection.md (0022 → 0032)

## Test plan
- [x] All 88 unit tests pass locally
- [ ] CI build passes
- [ ] CI tests pass on all platforms

Refs: #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)