### PR TITLE
chore: exclude thin wrapper services from code coverage

### DIFF
--- a/src/McjCoderOrg.ClaudeAutoResume/Services/ConsoleService.cs
+++ b/src/McjCoderOrg.ClaudeAutoResume/Services/ConsoleService.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace McjCoderOrg.ClaudeAutoResume.Services;
 
 /// <summary>
 /// Production implementation of <see cref="IConsoleService"/> wrapping System.Console.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Thin wrapper around System.Console with no testable logic")]
 internal sealed class ConsoleService : IConsoleService
 {
     /// <inheritdoc/>

--- a/src/McjCoderOrg.ClaudeAutoResume/Services/EnvironmentService.cs
+++ b/src/McjCoderOrg.ClaudeAutoResume/Services/EnvironmentService.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace McjCoderOrg.ClaudeAutoResume.Services;
 
 /// <summary>
 /// Production implementation of <see cref="IEnvironmentService"/> wrapping System.Environment and System.IO.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Thin wrapper around System.Environment and System.IO with no testable logic")]
 internal sealed class EnvironmentService : IEnvironmentService
 {
     /// <inheritdoc/>


### PR DESCRIPTION
Refs: #111

## Summary
- Add `ExcludeFromCodeCoverage` attribute to `ConsoleService` and `EnvironmentService`
- These are thin wrappers around `System.Console` and `System.Environment`/`System.IO` with no testable logic

## Impact
- Coverage accuracy improved from 55.0% to 57.6%
- Removes 45 lines of untestable wrapper code from coverage metrics

## Test Plan
- [x] Build succeeds
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)