### PR TITLE
refactor: remove duplicate console encoding and service locator pattern

### DIFF
--- a/src/McjCoderOrg.ClaudeAutoResume/Application.cs
+++ b/src/McjCoderOrg.ClaudeAutoResume/Application.cs
@@ -5,8 +5,6 @@ using System.Text;
 using McjCoderOrg.ClaudeAutoResume.Resources;
 using McjCoderOrg.ClaudeAutoResume.Services;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Serilog;
 
 namespace McjCoderOrg.ClaudeAutoResume;
@@ -22,7 +20,7 @@ internal sealed class Application : IApplication
 
     private readonly IArgumentParser _argumentParser;
     private readonly IConsoleService _console;
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IEnvironmentService _environment;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -30,26 +28,23 @@ internal sealed class Application : IApplication
     /// </summary>
     /// <param name="argumentParser">The argument parser.</param>
     /// <param name="console">The console service.</param>
-    /// <param name="serviceProvider">The service provider for creating monitors.</param>
+    /// <param name="environment">The environment service.</param>
     /// <param name="logger">The logger.</param>
     public Application(
         IArgumentParser argumentParser,
         IConsoleService console,
-        IServiceProvider serviceProvider,
+        IEnvironmentService environment,
         ILogger? logger = null)
     {
         _argumentParser = argumentParser;
         _console = console;
-        _serviceProvider = serviceProvider;
+        _environment = environment;
         _logger = logger ?? Log.Logger;
     }
 
     /// <inheritdoc/>
     public async Task<int> RunAsync(string[] args)
     {
-        Console.OutputEncoding = Encoding.UTF8;
-        Console.InputEncoding = Encoding.UTF8;
-
         var parseResult = _argumentParser.Parse(args);
 
         if (parseResult.ShowHelp)
@@ -101,10 +96,7 @@ internal sealed class Application : IApplication
 
     private ClaudeMonitor CreateMonitor(WrapperConfig config)
     {
-        // Create monitor with DI services
-        var console = _serviceProvider.GetRequiredService<IConsoleService>();
-        var environment = _serviceProvider.GetRequiredService<IEnvironmentService>();
-        return new ClaudeMonitor(config, console, environment, _logger);
+        return new ClaudeMonitor(config, _console, _environment, _logger);
     }
 
     private static string? ValidateArguments(ParseResult result)

--- a/tests/McjCoderOrg.ClaudeAutoResume.Tests/ProgramTests.cs
+++ b/tests/McjCoderOrg.ClaudeAutoResume.Tests/ProgramTests.cs
@@ -10,36 +10,29 @@ public sealed class ProgramTests
 {
     private readonly ITestOutputHelper _output;
     private readonly Mock<IConsoleService> _mockConsole;
-    private readonly Mock<IServiceProvider> _mockServiceProvider;
+    private readonly Mock<IEnvironmentService> _mockEnvironment;
     private Application _app = null!;
 
     public ProgramTests(ITestOutputHelper output)
     {
         _output = output;
         _mockConsole = new Mock<IConsoleService>(MockBehavior.Loose);
-        _mockServiceProvider = new Mock<IServiceProvider>(MockBehavior.Loose);
+        _mockEnvironment = new Mock<IEnvironmentService>(MockBehavior.Loose);
 
         // Setup console mock
         _mockConsole.Setup(c => c.WindowWidth).Returns(120);
         _mockConsole.Setup(c => c.WindowHeight).Returns(30);
+
+        // Setup environment mock
+        _mockEnvironment.Setup(e => e.CurrentDirectory).Returns(Environment.CurrentDirectory);
+        _mockEnvironment.Setup(e => e.GetEnvironmentVariables()).Returns(new Dictionary<string, string>(StringComparer.Ordinal));
     }
 
     private Application CreateApplication(Mock<IArgumentParser>? parserMock = null)
     {
-        var mockEnvironment = new Mock<IEnvironmentService>(MockBehavior.Loose);
-        mockEnvironment.Setup(e => e.CurrentDirectory).Returns(Environment.CurrentDirectory);
-        mockEnvironment.Setup(e => e.GetEnvironmentVariables()).Returns(new Dictionary<string, string>(StringComparer.Ordinal));
+        var parser = parserMock?.Object ?? new ArgumentParser(_mockEnvironment.Object);
 
-        var parser = parserMock?.Object ?? new ArgumentParser(mockEnvironment.Object);
-
-        _mockServiceProvider
-            .Setup(sp => sp.GetService(typeof(IConsoleService)))
-            .Returns(_mockConsole.Object);
-        _mockServiceProvider
-            .Setup(sp => sp.GetService(typeof(IEnvironmentService)))
-            .Returns(mockEnvironment.Object);
-
-        return new Application(parser, _mockConsole.Object, _mockServiceProvider.Object);
+        return new Application(parser, _mockConsole.Object, _mockEnvironment.Object);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Removed duplicate Console.OutputEncoding/InputEncoding from Application.cs (already set in Program.cs bootstrap)
- Replaced Service Locator pattern with constructor injection for IEnvironmentService
- Application now receives all dependencies through constructor, improving testability

## Changes
- `Application.cs`: Removed duplicate encoding calls, removed IServiceProvider dependency, inject IEnvironmentService directly
- `ProgramTests.cs`: Updated to use direct IEnvironmentService mock instead of IServiceProvider

Closes #129

## Test Plan
- [x] All unit tests pass (163 tests)
- [x] All system tests pass (25 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)