### PR TITLE
fix(ci): add --fail-on-errors to danger ci command

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm ci
 
       - name: Run Danger
-        run: npx danger ci
+        run: npx danger ci --fail-on-errors
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--fail-on-errors` flag to `danger ci` command in workflow
- Without this flag, workflow passes even when Danger finds rule violations

## Problem
Two separate checks were created:
1. **Check Run** ("Danger PR Validation") - Always passed if workflow completed
2. **Status Context** ("Danger") - Showed actual failures

This allowed PR #130 to merge despite Danger showing failures.

## Fix
```diff
- run: npx danger ci
+ run: npx danger ci --fail-on-errors
```

Now the workflow will fail when Danger finds issues, blocking the merge.

Closes: #131

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Test on a PR with Danger violations to confirm it blocks merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)